### PR TITLE
fix: Security audit fixes for v2.1.0 (XSW, SSRF, conditions, role guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0 (2026-04-25)
+
+### Security
+
+- **[Critical]** Fix SAML XML Signature Wrapping (XSW) — require assertion-level signature, reject response-only signatures that allow forged assertions to bypass authentication (#5)
+- **[Critical]** Guard against privilege escalation via SSO default role — block `administrator` as default role in settings sanitization (#6)
+- **[Medium]** Enforce SAML assertion conditions (NotBefore, NotOnOrAfter, AudienceRestriction) — prevents replay attacks with expired assertions (#7)
+- **[Medium]** Add SSRF protection to SAML metadata import — host allowlist (Entra endpoints only) and private IP blocking (#8)
+
+### Changed
+
+- Default role for SSO auto-provisioning now defaults to `subscriber` (was `editor` in some deployments)
+- Metadata import restricted to known Microsoft Entra hosts: `login.microsoftonline.com`, `login.windows.net`, `login.microsoftonline.us`, `login.chinacloudapi.cn`
+
 ## 2.0.3 (2026-04-17)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Click the **Help** button (top-right) on the settings page for step-by-step guid
 - **SAML Setup** — Entity ID, ACS URL, NinjaFirewall notes
 - **Troubleshooting** — Common errors and fixes
 
+## Security Hardening (v2.1.0)
+
+- SAML assertions must be individually signed — response-level-only signatures are rejected (XSW prevention)
+- Assertion conditions (NotBefore, NotOnOrAfter, AudienceRestriction) are strictly enforced
+- Metadata import is restricted to known Microsoft Entra hosts with private IP blocking
+- `administrator` role is blocked as the SSO default role
+- Default role for new SSO users is `subscriber`
+
 ## NinjaFirewall Compatibility
 
 If you use NinjaFirewall, create a `.htninja` file in your document root:

--- a/includes/admin/class-settings-fields.php
+++ b/includes/admin/class-settings-fields.php
@@ -219,14 +219,29 @@ class Settings_Fields {
 	}
 
 	/**
-	 * Sanitize a WordPress role slug.
+	 * Sanitize a WordPress role slug for SSO default role.
+	 *
+	 * Security: blocks 'administrator' to prevent privilege escalation
+	 * through SSO auto-provisioning misconfiguration.
 	 *
 	 * @param mixed $value Raw input.
-	 * @return string Role slug if it exists, otherwise 'subscriber'.
+	 * @return string Role slug if valid and not administrator, otherwise 'subscriber'.
 	 */
 	public static function sanitize_role( $value ): string {
 		$value = sanitize_text_field( (string) $value );
 		$roles = wp_roles()->get_names();
+
+		// Security: never allow administrator as the SSO default role.
+		if ( 'administrator' === $value ) {
+			add_settings_error(
+				\SFME\Plugin::OPTION_DEFAULT_ROLE,
+				'sfme_role_too_high',
+				__( 'Administrator cannot be set as the SSO default role. Reset to Subscriber.', 'sso-for-microsoft-entra' ),
+				'error'
+			);
+			return 'subscriber';
+		}
+
 		return isset( $roles[ $value ] ) ? $value : 'subscriber';
 	}
 

--- a/includes/auth/class-saml-client.php
+++ b/includes/auth/class-saml-client.php
@@ -262,7 +262,7 @@ class SAML_Client {
 	 * replay attacks and cross-SP assertion injection.
 	 *
 	 * @param \LightSaml\Model\Assertion\Assertion $assertion LightSaml assertion.
-	 * @param array                                 $config    SAML config with entity_id.
+	 * @param array                                $config    SAML config with entity_id.
 	 * @return true|\WP_Error True when conditions pass, WP_Error otherwise.
 	 */
 	private static function validate_conditions_lightsaml( \LightSaml\Model\Assertion\Assertion $assertion, array $config ) {

--- a/includes/auth/class-saml-client.php
+++ b/includes/auth/class-saml-client.php
@@ -192,30 +192,45 @@ class SAML_Client {
 			);
 		}
 
-		// Verify signature on either the assertion or the response.
+		// Security (XSW-1): require the assertion itself to be signed.
+		// Accepting a response-level signature for an unsigned assertion
+		// enables XML Signature Wrapping: an attacker can move the signed
+		// assertion deeper in the tree and prepend a forged one that
+		// getFirstAssertion() would return instead.
+		$assertion_signature = $assertion->getSignature();
+
+		if ( ! $assertion_signature ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'SFME SAML: assertion is not signed — rejecting to prevent XSW attacks.' );
+			}
+			return new \WP_Error(
+				'saml_unsigned_assertion',
+				esc_html__( 'SAML assertion must be individually signed. Response-level signatures alone are not accepted.', 'sso-for-microsoft-entra' )
+			);
+		}
+
+		// Verify the assertion signature against our stored certificates.
 		$signature_valid = false;
-		$signature       = $assertion->getSignature() ?? $response->getSignature();
 
-		if ( $signature ) {
-			foreach ( $certificates as $cert ) {
-				try {
-					$cert_clean = str_replace( array( "\n", "\r", ' ' ), '', $cert );
-					$pem        = "-----BEGIN CERTIFICATE-----\n"
-						. chunk_split( $cert_clean, 64, "\n" )
-						. "-----END CERTIFICATE-----\n";
+		foreach ( $certificates as $cert ) {
+			try {
+				$cert_clean = str_replace( array( "\n", "\r", ' ' ), '', $cert );
+				$pem        = "-----BEGIN CERTIFICATE-----\n"
+					. chunk_split( $cert_clean, 64, "\n" )
+					. "-----END CERTIFICATE-----\n";
 
-					$x509 = new \LightSaml\Credential\X509Certificate();
-					$x509->loadPem( $pem );
-					$key = \LightSaml\Credential\KeyHelper::createPublicKey( $x509 );
+				$x509 = new \LightSaml\Credential\X509Certificate();
+				$x509->loadPem( $pem );
+				$key = \LightSaml\Credential\KeyHelper::createPublicKey( $x509 );
 
-					if ( $signature->validate( $key ) ) {
-						$signature_valid = true;
-						break;
-					}
-				} catch ( \Exception $e ) {
-					// Try next certificate.
-					continue;
+				if ( $assertion_signature->validate( $key ) ) {
+					$signature_valid = true;
+					break;
 				}
+			} catch ( \Exception $e ) {
+				// Try next certificate.
+				continue;
 			}
 		}
 
@@ -226,12 +241,95 @@ class SAML_Client {
 			}
 			return new \WP_Error(
 				'saml_invalid_signature',
-				esc_html__( 'SAML response signature verification failed.', 'sso-for-microsoft-entra' )
+				esc_html__( 'SAML assertion signature verification failed.', 'sso-for-microsoft-entra' )
 			);
+		}
+
+		// Validate assertion conditions (NotBefore, NotOnOrAfter, Audience).
+		$conditions_result = self::validate_conditions_lightsaml( $assertion, $config );
+		if ( is_wp_error( $conditions_result ) ) {
+			return $conditions_result;
 		}
 
 		// Extract claims from the assertion using LightSaml objects.
 		return self::extract_claims_from_lightsaml( $assertion );
+	}
+
+	/**
+	 * Validate assertion conditions using a LightSaml Assertion object.
+	 *
+	 * Checks NotBefore, NotOnOrAfter, and AudienceRestriction to prevent
+	 * replay attacks and cross-SP assertion injection.
+	 *
+	 * @param \LightSaml\Model\Assertion\Assertion $assertion LightSaml assertion.
+	 * @param array                                 $config    SAML config with entity_id.
+	 * @return true|\WP_Error True when conditions pass, WP_Error otherwise.
+	 */
+	private static function validate_conditions_lightsaml( \LightSaml\Model\Assertion\Assertion $assertion, array $config ) {
+		$conditions = $assertion->getConditions();
+
+		if ( ! $conditions ) {
+			return new \WP_Error(
+				'saml_missing_conditions',
+				esc_html__( 'SAML assertion is missing a Conditions element.', 'sso-for-microsoft-entra' )
+			);
+		}
+
+		$now = time();
+
+		// ── NotBefore ─────────────────────────────────────────────────────── //
+		$not_before = $conditions->getNotBeforeTimestamp();
+
+		if ( null !== $not_before && $now < ( $not_before - self::CLOCK_SKEW ) ) {
+			return new \WP_Error(
+				'saml_assertion_not_yet_valid',
+				esc_html__( 'SAML assertion is not yet valid (NotBefore).', 'sso-for-microsoft-entra' )
+			);
+		}
+
+		// ── NotOnOrAfter ──────────────────────────────────────────────────── //
+		$not_on_or_after = $conditions->getNotOnOrAfterTimestamp();
+
+		if ( null !== $not_on_or_after && $now >= ( $not_on_or_after + self::CLOCK_SKEW ) ) {
+			return new \WP_Error(
+				'saml_assertion_expired',
+				esc_html__( 'SAML assertion has expired (NotOnOrAfter).', 'sso-for-microsoft-entra' )
+			);
+		}
+
+		// ── AudienceRestriction ───────────────────────────────────────────── //
+		$audience_restrictions = $conditions->getAllAudienceRestrictions();
+
+		if ( empty( $audience_restrictions ) ) {
+			return new \WP_Error(
+				'saml_missing_audience',
+				esc_html__( 'SAML assertion is missing an AudienceRestriction element.', 'sso-for-microsoft-entra' )
+			);
+		}
+
+		$client_id = (string) Plugin::get_instance()->get_option( Plugin::OPTION_CLIENT_ID, '' );
+		$entity_id = $config['entity_id'] ?? home_url();
+
+		$audience_match = false;
+
+		foreach ( $audience_restrictions as $restriction ) {
+			foreach ( $restriction->getAllAudience() as $audience ) {
+				$audience_value = $audience->getValue();
+				if ( $entity_id === $audience_value || home_url() === $audience_value || $client_id === $audience_value ) {
+					$audience_match = true;
+					break 2;
+				}
+			}
+		}
+
+		if ( ! $audience_match ) {
+			return new \WP_Error(
+				'saml_audience_mismatch',
+				esc_html__( 'SAML assertion audience does not match this service provider.', 'sso-for-microsoft-entra' )
+			);
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/xml/class-xml-security.php
+++ b/includes/xml/class-xml-security.php
@@ -142,6 +142,24 @@ class XML_Security {
 			);
 		}
 
+		// Security (SSRF-1): only allow known Entra federation metadata hosts.
+		$host = strtolower( $parsed['host'] );
+		if ( ! self::is_allowed_metadata_host( $host ) ) {
+			return new \WP_Error(
+				'xml_url_blocked_host',
+				esc_html__( 'This host is not in the allowlist for SAML metadata retrieval. Only login.microsoftonline.com and login.windows.net are accepted.', 'sso-for-microsoft-entra' )
+			);
+		}
+
+		// Security (SSRF-2): resolve hostname and block private/internal IPs.
+		$resolved_ip = gethostbyname( $host );
+		if ( $resolved_ip === $host || self::is_private_ip( $resolved_ip ) ) {
+			return new \WP_Error(
+				'xml_url_private_ip',
+				esc_html__( 'The metadata URL resolves to a private or internal IP address.', 'sso-for-microsoft-entra' )
+			);
+		}
+
 		// ----- Remote fetch ------------------------------------------------- //
 		$response = wp_remote_get(
 			$url,
@@ -203,5 +221,45 @@ class XML_Security {
 		// Delegate to the hardened string parser (size check + XXE prevention
 		// are both applied inside safe_load_xml()).
 		return self::safe_load_xml( $body );
+	}
+
+	// -------------------------------------------------------------------------
+	// SSRF prevention helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Check whether a hostname is in the allowlist for metadata retrieval.
+	 *
+	 * Only Microsoft Entra federation metadata endpoints are accepted.
+	 *
+	 * @param string $host Lowercase hostname to check.
+	 * @return bool True if the host is allowed.
+	 */
+	private static function is_allowed_metadata_host( string $host ): bool {
+		$allowed = array(
+			'login.microsoftonline.com',
+			'login.windows.net',
+			'login.microsoftonline.us',   // US Government cloud.
+			'login.chinacloudapi.cn',     // China cloud.
+		);
+
+		return in_array( $host, $allowed, true );
+	}
+
+	/**
+	 * Check whether an IP address belongs to a private or reserved range.
+	 *
+	 * Blocks RFC 1918, loopback, link-local, and other internal ranges to
+	 * prevent SSRF attacks that target internal infrastructure.
+	 *
+	 * @param string $ip IPv4 address to check.
+	 * @return bool True if the IP is private/reserved (should be blocked).
+	 */
+	private static function is_private_ip( string $ip ): bool {
+		return ! filter_var(
+			$ip,
+			FILTER_VALIDATE_IP,
+			FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+		);
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: sso, microsoft, entra, azure, openid-connect, saml, single-sign-on
 Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable tag: 2.0.3
+Stable tag: 2.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/sso-for-microsoft-entra.php
+++ b/sso-for-microsoft-entra.php
@@ -3,7 +3,7 @@
  * Plugin Name:       SSO for Microsoft Entra
  * Plugin URI:        https://github.com/codetot-web/sso-for-microsoft-entra
  * Description:       Single Sign-On authentication for WordPress using Microsoft Entra ID (Azure AD). Supports OpenID Connect with PKCE and SAML 2.0.
- * * Version:           2.0.3
+ * Version:           2.1.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            Khoi Pro, CODE TOT
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @var string
  */
-define( 'SFME_VERSION', '2.0.3' );
+define( 'SFME_VERSION', '2.1.0' );
 
 /**
  * Absolute path to the main plugin file.


### PR DESCRIPTION
## Summary

Patches 4 security vulnerabilities found in plugin v2.0.3 via internal penetration testing.

- **[Critical] XSW fix (#5):** Require assertion-level signature — reject response-only signatures that allow XML Signature Wrapping attacks to forge SAML assertions and bypass authentication
- **[Critical] Role guard (#6):** Block `administrator` as SSO default role in settings sanitization to prevent privilege escalation through misconfiguration
- **[Medium] Conditions validation (#7):** Add `validate_conditions_lightsaml()` to enforce NotBefore/NotOnOrAfter/AudienceRestriction on every SAML login — prevents replay attacks
- **[Medium] SSRF protection (#8):** Add host allowlist (Entra endpoints only) and private IP blocking for SAML metadata import URL

## Additional mitigations applied

- `sfme_default_role` changed from `editor` to `subscriber`
- `sfme_user_provisioning` disabled
- `DISALLOW_FILE_EDIT` enabled in wp-config.php
- Excessive capabilities removed from Editor role
- Pentest test accounts deleted

## Test plan

- [ ] SAML login with assertion-level signature works normally
- [ ] SAML login with response-only signature is rejected with clear error
- [ ] Expired SAML assertion is rejected (NotOnOrAfter)
- [ ] Metadata import from `login.microsoftonline.com` works
- [ ] Metadata import from `localhost` or private IP is blocked
- [ ] Setting default role to `administrator` shows error and resets to `subscriber`
- [ ] Version shows 2.1.0

Closes #5, closes #6, closes #7, closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)