### PR TITLE
Fix /sso/login 404 after activation (closes #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.1 (2026-04-28)
+
+### Fixed
+
+- `/sso/login` returning 404 after activation — rewrite rule is now registered in the activation hook before `flush_rewrite_rules()` so it is included in the persisted rules (#18)
+
 ## 2.5.0 (2026-04-28)
 
 ### Breaking

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: sso, microsoft, entra, azure, single-sign-on
 Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable tag: 2.5.0
+Stable tag: 2.5.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -90,6 +90,9 @@ Yes. Encrypted using libsodium (XSalsa20-Poly1305) or AES-256-GCM with a key der
 2. **Login page** — Microsoft sign-in button on the WordPress login form.
 
 == Changelog ==
+
+= 2.5.1 =
+* **Fixed:** `/sso/login` returning 404 after activation — rewrite rule is now registered before flush.
 
 = 2.5.0 =
 * **Breaking:** Removed role mapping and default role selector. All new SSO users are assigned the Subscriber role. Administrators promote users manually.

--- a/sso-for-microsoft-entra.php
+++ b/sso-for-microsoft-entra.php
@@ -3,7 +3,7 @@
  * Plugin Name:       SSO for Microsoft Entra
  * Plugin URI:        https://github.com/codetot-web/sso-for-microsoft-entra
  * Description:       Single Sign-On authentication for WordPress using Microsoft Entra ID (Azure AD) via OpenID Connect with PKCE.
- * Version:           2.5.0
+ * Version:           2.5.1
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            Khoi Pro, CODE TOT
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @var string
  */
-define( 'SFME_VERSION', '2.5.0' );
+define( 'SFME_VERSION', '2.5.1' );
 
 /**
  * Absolute path to the main plugin file.
@@ -130,6 +130,10 @@ register_activation_hook(
 			}
 		}
 
+		// Register the rewrite rule before flushing so it is included in the
+		// persisted rules. On normal page loads this is done via the init hook,
+		// but during activation init may not have fired yet.
+		add_rewrite_rule( '^sso/([a-z-]+)/?$', 'index.php?sfme_action=$matches[1]', 'top' );
 		flush_rewrite_rules();
 	}
 );


### PR DESCRIPTION
## Summary

- Register the rewrite rule in the activation hook before `flush_rewrite_rules()` so `/sso/login` works immediately after activation
- Bump version to 2.5.1

Closes #18

## Test plan

- [x] Deactivate and delete plugin, reinstall from zip, activate
- [x] Visit `/sso/login` — should redirect to Microsoft (or show "SSO not configured"), not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)