### PR TITLE
fix: append appid to JWKS URI for per-app signing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.2 (2026-05-05)
+
+### Fixed
+
+- ID token signature verification failed (`jwt_signature_invalid`) for Entra apps configured with per-application signing keys (optional claims or custom token signing policy). The JWKS URI now includes `?appid={client_id}` so the app-specific signing key is returned. Without this, `/discovery/v2.0/keys` omits the key Entra used to sign the id_token and validation fails even though the token is genuine.
+
 ## 2.5.1 (2026-04-28)
 
 ### Fixed

--- a/includes/auth/class-oidc-client.php
+++ b/includes/auth/class-oidc-client.php
@@ -228,10 +228,22 @@ class OIDC_Client {
 			);
 		}
 
+		// Per-app signing keys: Entra apps configured with optional claims
+		// or a custom token signing policy sign id_tokens with a key that
+		// only appears in the JWKS document when the appid query parameter
+		// is appended. Without it, the standard /discovery/v2.0/keys
+		// response omits that key and signature validation fails with
+		// jwt_signature_invalid even though the token is genuine.
+		// See https://learn.microsoft.com/azure/active-directory/develop/access-tokens#validating-tokens.
+		$jwks_uri_with_appid = $discovery['jwks_uri'];
+		if ( '' !== $client_id ) {
+			$jwks_uri_with_appid = add_query_arg( 'appid', $client_id, $jwks_uri_with_appid );
+		}
+
 		$expected = array(
 			'client_id' => $client_id,
 			'issuer'    => $discovery['issuer'],
-			'jwks_uri'  => $discovery['jwks_uri'],
+			'jwks_uri'  => $jwks_uri_with_appid,
 			'nonce'     => $nonce_from_token,
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: sso, microsoft, entra, azure, single-sign-on
 Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable tag: 2.5.1
+Stable tag: 2.5.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -90,6 +90,9 @@ Yes. Encrypted using libsodium (XSalsa20-Poly1305) or AES-256-GCM with a key der
 2. **Login page** — Microsoft sign-in button on the WordPress login form.
 
 == Changelog ==
+
+= 2.5.2 =
+* **Fixed:** ID token signature verification failed (`jwt_signature_invalid`) for Entra apps that use per-application signing keys. The plugin now appends `?appid={client_id}` when fetching the JWKS so the app-specific signing key is included.
 
 = 2.5.1 =
 * **Fixed:** `/sso/login` returning 404 after activation — rewrite rule is now registered before flush.

--- a/sso-for-microsoft-entra.php
+++ b/sso-for-microsoft-entra.php
@@ -3,7 +3,7 @@
  * Plugin Name:       SSO for Microsoft Entra
  * Plugin URI:        https://github.com/codetot-web/sso-for-microsoft-entra
  * Description:       Single Sign-On authentication for WordPress using Microsoft Entra ID (Azure AD) via OpenID Connect with PKCE.
- * Version:           2.5.1
+ * Version:           2.5.2
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            Khoi Pro, CODE TOT
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @var string
  */
-define( 'SFME_VERSION', '2.5.1' );
+define( 'SFME_VERSION', '2.5.2' );
 
 /**
  * Absolute path to the main plugin file.


### PR DESCRIPTION
## Summary

- Append `?appid={client_id}` to the discovery `jwks_uri` so Entra apps with per-application signing keys (optional claims or custom token signing policy) return the actual signing key.
- Bump plugin version to 2.5.2 and update CHANGELOG/readme.

Closes #20.

## Why

Without `?appid=`, `/discovery/v2.0/keys` returns only the global tenant signing keys. Apps with per-application keys sign id_tokens with a key that lives at the app-scoped JWKS endpoint. Validation fails with `jwt_signature_invalid` even though the token is genuine.

## Test plan

- [x] phpcs passes (`vendor/bin/phpcs --standard=phpcs.xml.dist`)
- [x] phpunit passes (43 tests, 66 assertions)
- [x] Verified end-to-end on staging (msngroup.codetot.org): SSO login that previously failed with `jwt_signature_invalid` now succeeds
- [ ] Confirm new-user auto-provisioning on staging