### PR TITLE
feat: add Debug Log tab with last 100 auth sessions (closes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.7.0 (2026-06-25)
+
+### Added
+
+- Debug Log tab in admin settings with Enable Debug Log toggle (default: off).
+- Log table showing last 100 authentication sessions (newest first) with timestamp, event, status, email, IP, and error columns.
+- Delete Log button to clear all entries via AJAX.
+- Logging hooks into login success, callback errors, rate-limit triggers, user provisioning, and user-not-found events.
+- PHPUnit tests for the Debug_Logger class.
+
 ## 2.6.1 (2026-06-25)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log table showing last 100 authentication sessions (newest first) with timestamp, event, status, email, IP, and error columns.
 - Delete Log button to clear all entries via AJAX.
 - Logging hooks into login success, callback errors, rate-limit triggers, user provisioning, and user-not-found events.
+- Auth log entries are automatically cleared on plugin deactivation.
 - PHPUnit tests for the Debug_Logger class.
 
 ## 2.6.1 (2026-06-25)

--- a/includes/admin/class-settings-fields.php
+++ b/includes/admin/class-settings-fields.php
@@ -158,6 +158,22 @@ class Settings_Fields {
 		);
 	}
 
+	/**
+	 * Return field definitions for the \"Debug Log\" section.
+	 *
+	 * @return array[]
+	 */
+	public static function debug_log_fields(): array {
+		return array(
+			array(
+				'id'          => \SFME\Plugin::OPTION_DEBUG_LOG_ENABLED,
+				'label'       => __( 'Enable Debug Log', 'sso-for-microsoft-entra' ),
+				'type'        => 'checkbox',
+				'description' => __( 'Log the last 100 SSO authentication sessions. Disabled by default.', 'sso-for-microsoft-entra' ),
+			),
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// Sanitization helpers
 	// -------------------------------------------------------------------------

--- a/includes/admin/class-settings-page.php
+++ b/includes/admin/class-settings-page.php
@@ -13,6 +13,8 @@ namespace SFME\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use SFME\Debug\Debug_Logger;
+
 /**
  * Class Settings_Page
  *
@@ -402,6 +404,34 @@ class Settings_Page {
 				$field
 			);
 		}
+
+		// --- Section: Debug Log ---
+		add_settings_section(
+			'sfme_section_debug_log',
+			__( 'Debug Log', 'sso-for-microsoft-entra' ),
+			array( self::class, 'render_section_debug_log' ),
+			self::PAGE_SLUG
+		);
+
+		register_setting(
+			self::OPTION_GROUP,
+			\SFME\Plugin::OPTION_DEBUG_LOG_ENABLED,
+			array( 'sanitize_callback' => 'absint' )
+		);
+
+		foreach ( Settings_Fields::debug_log_fields() as $field ) {
+			add_settings_field(
+				$field['id'],
+				esc_html( $field['label'] ),
+				array( self::class, 'render_field' ),
+				self::PAGE_SLUG,
+				'sfme_section_debug_log',
+				$field
+			);
+		}
+
+		// Register the AJAX clear-log action.
+		add_action( 'wp_ajax_sfme_clear_logs', array( self::class, 'handle_clear_logs' ) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -474,6 +504,102 @@ class Settings_Page {
 	 */
 	public static function render_section_rate_limiting(): void {
 		echo '<p>' . esc_html__( 'Control how many SSO login attempts are allowed per IP address within a time window.', 'sso-for-microsoft-entra' ) . '</p>';
+	}
+
+	/**
+	 * Render the Debug Log section — toggle, log table, and clear button.
+	 *
+	 * When debug logging is enabled, the last 100 auth sessions are displayed
+	 * in a table. A button clears all entries via AJAX.
+	 *
+	 * @return void
+	 */
+	public static function render_section_debug_log(): void {
+		echo '<p>' . esc_html__( 'Log authentication events for troubleshooting. Not saved when disabled.', 'sso-for-microsoft-entra' ) . '</p>';
+
+		if ( ! Debug_Logger::is_enabled() ) {
+			return;
+		}
+
+		$logs = Debug_Logger::get_logs();
+
+		if ( empty( $logs ) ) {
+			echo '<p><em>' . esc_html__( 'No log entries yet.', 'sso-for-microsoft-entra' ) . '</em></p>';
+			return;
+		}
+
+		?>
+		<table class="widefat striped" style="margin-top:12px">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Time', 'sso-for-microsoft-entra' ); ?></th>
+					<th><?php esc_html_e( 'Event', 'sso-for-microsoft-entra' ); ?></th>
+					<th><?php esc_html_e( 'Status', 'sso-for-microsoft-entra' ); ?></th>
+					<th><?php esc_html_e( 'Email', 'sso-for-microsoft-entra' ); ?></th>
+					<th><?php esc_html_e( 'IP', 'sso-for-microsoft-entra' ); ?></th>
+					<th><?php esc_html_e( 'Error', 'sso-for-microsoft-entra' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $logs as $entry ) : ?>
+					<tr>
+						<td><?php echo esc_html( wp_date( 'Y-m-d H:i:s', (int) ( $entry['timestamp'] ?? 0 ) ) ); ?></td>
+						<td><?php echo esc_html( $entry['event'] ?? '' ); ?></td>
+						<td>
+							<?php if ( 'success' === ( $entry['status'] ?? '' ) ) : ?>
+								<span style="color:green"><?php esc_html_e( 'Success', 'sso-for-microsoft-entra' ); ?></span>
+							<?php else : ?>
+								<span style="color:red"><?php esc_html_e( 'Failure', 'sso-for-microsoft-entra' ); ?></span>
+							<?php endif; ?>
+						</td>
+						<td><?php echo esc_html( $entry['email'] ?? '' ); ?></td>
+						<td><?php echo esc_html( $entry['ip'] ?? '' ); ?></td>
+						<td><?php echo esc_html( $entry['error'] ?? '' ); ?></td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+		<p>
+			<button type="button" class="button button-secondary" id="sfme-clear-logs">
+				<?php esc_html_e( 'Delete Log', 'sso-for-microsoft-entra' ); ?>
+			</button>
+		</p>
+		<script type="text/javascript">
+		jQuery(document).ready(function($) {
+			$('#sfme-clear-logs').on('click', function() {
+				if ( ! confirm( '<?php echo esc_js( __( 'Are you sure you want to delete all log entries?', 'sso-for-microsoft-entra' ) ); ?>' ) ) {
+					return;
+				}
+				$.post(ajaxurl, {
+					action: 'sfme_clear_logs',
+					_ajax_nonce: '<?php echo esc_js( wp_create_nonce( 'sfme_clear_logs' ) ); ?>'
+				}, function(response) {
+					if ( response.success ) {
+						location.reload();
+					} else {
+						alert( response.data || '<?php echo esc_js( __( 'Failed to clear logs.', 'sso-for-microsoft-entra' ) ); ?>' );
+					}
+				});
+			});
+		});
+		</script>
+		<?php
+	}
+
+	/**
+	 * AJAX handler for clearing the debug log.
+	 *
+	 * @return void
+	 */
+	public static function handle_clear_logs(): void {
+		check_ajax_referer( 'sfme_clear_logs' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( -1 );
+		}
+
+		Debug_Logger::clear_logs();
+		wp_send_json_success();
 	}
 
 	// -------------------------------------------------------------------------

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -57,6 +57,16 @@ class Plugin {
 	 */
 	const OPTION_RATE_LIMIT_WINDOW = 'sfme_rate_limit_window';
 
+	/**
+	 * Whether debug logging is enabled.
+	 */
+	const OPTION_DEBUG_LOG_ENABLED = 'sfme_debug_log_enabled';
+
+	/**
+	 * Stored authentication log entries (JSON array).
+	 */
+	const OPTION_AUTH_LOGS = 'sfme_auth_logs';
+
 	// -------------------------------------------------------------------------
 	// Singleton
 	// -------------------------------------------------------------------------

--- a/includes/debug/class-debug-logger.php
+++ b/includes/debug/class-debug-logger.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Debug logger for authentication events.
+ *
+ * Captures the last 100 SSO authentication sessions when debug logging is
+ * explicitly enabled. Defaults to off to avoid unnecessary writes.
+ *
+ * @package SFME\Debug
+ */
+
+namespace SFME\Debug;
+
+use SFME\Plugin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Debug_Logger
+ *
+ * All methods are static. Each log entry records:
+ *  - timestamp (Unix)
+ *  - event    ('login_success', 'login_failure', 'callback_error', etc.)
+ *  - email    (user email or empty)
+ *  - ip       (client IP)
+ *  - error    (machine-readable error code, empty on success)
+ *  - user_agent (HTTP User-Agent string, truncated)
+ */
+class Debug_Logger {
+
+	/**
+	 * Max log entries kept.
+	 *
+	 * @var int
+	 */
+	const MAX_ENTRIES = 100;
+
+	/**
+	 * Log an authentication event.
+	 *
+	 * @param string $event  Event type (e.g. 'login_success', 'login_failure').
+	 * @param string $status 'success' or 'failure'.
+	 * @param string $email  User email (or '' if unknown).
+	 * @param string $error  Machine-readable error code (or '' on success).
+	 *
+	 * @return void
+	 */
+	public static function log( string $event, string $status, string $email = '', string $error = '' ): void {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
+		$logs  = self::get_logs();
+		$entry = array(
+			'timestamp'  => time(),
+			'event'      => $event,
+			'status'     => 'success' === $status ? 'success' : 'failure',
+			'email'      => $email,
+			'ip'         => self::get_client_ip(),
+			'error'      => $error,
+			'user_agent' => self::get_user_agent(),
+		);
+
+		// Prepend newest entry.
+		array_unshift( $logs, $entry );
+
+		// Trim to MAX_ENTRIES.
+		if ( count( $logs ) > self::MAX_ENTRIES ) {
+			$logs = array_slice( $logs, 0, self::MAX_ENTRIES );
+		}
+
+		update_option( Plugin::OPTION_AUTH_LOGS, wp_json_encode( $logs ), false );
+	}
+
+	/**
+	 * Retrieve stored log entries.
+	 *
+	 * @return array[] Array of log entry arrays.
+	 */
+	public static function get_logs(): array {
+		$raw  = get_option( Plugin::OPTION_AUTH_LOGS, '[]' );
+		$data = json_decode( $raw, true );
+
+		return is_array( $data ) ? $data : array();
+	}
+
+	/**
+	 * Delete all log entries.
+	 *
+	 * @return void
+	 */
+	public static function clear_logs(): void {
+		delete_option( Plugin::OPTION_AUTH_LOGS );
+	}
+
+	/**
+	 * Check whether debug logging is enabled.
+	 *
+	 * Reads the option directly to avoid bootstrapping the full plugin singleton.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled(): bool {
+		return (bool) get_option( Plugin::OPTION_DEBUG_LOG_ENABLED, false );
+	}
+
+	/**
+	 * Obtain the client IP address.
+	 *
+	 * @return string
+	 */
+	private static function get_client_ip(): string {
+		if ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+			return sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Obtain the User-Agent string (truncated to 255 chars).
+	 *
+	 * @return string
+	 */
+	private static function get_user_agent(): string {
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return substr( sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ), 0, 255 );
+		}
+
+		return '';
+	}
+}

--- a/includes/login/class-login-handler.php
+++ b/includes/login/class-login-handler.php
@@ -19,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
 
 use SFME\Plugin;
 use SFME\Auth\OIDC_Client;
+use SFME\Debug\Debug_Logger;
 use SFME\Security\Rate_Limiter;
 use SFME\Security\State_Manager;
 use SFME\User\User_Handler;
@@ -185,6 +186,7 @@ class Login_Handler {
 		// internally, but we check here first to fail fast before building params.
 		$ip = self::get_client_ip();
 		if ( ! Rate_Limiter::check( $ip ) ) {
+			Debug_Logger::log( 'rate_limited', 'failure', '', 'rate_limited' );
 			self::redirect_with_error( 'rate_limited' );
 			return;
 		}
@@ -202,6 +204,7 @@ class Login_Handler {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional debug logging when WP_DEBUG is enabled
 				error_log( 'SFME OIDC callback error: ' . $claims->get_error_message() );
 			}
+			Debug_Logger::log( 'callback_error', 'failure', '', 'oidc_callback_failed' );
 			self::redirect_with_error( 'oidc_callback_failed' );
 			return;
 		}
@@ -358,6 +361,15 @@ class Login_Handler {
 		// Establish the WordPress session.
 		wp_set_current_user( $user_id );
 		wp_set_auth_cookie( $user_id, false );
+
+		// Log successful authentication.
+		$user = get_userdata( $user_id );
+		Debug_Logger::log(
+			'login_success',
+			'success',
+			$user ? $user->user_email : '',
+			''
+		);
 
 		/**
 		 * Fires after a user has been authenticated via Entra SSO.

--- a/includes/user/class-user-handler.php
+++ b/includes/user/class-user-handler.php
@@ -16,6 +16,8 @@ namespace SFME\User;
 
 defined( 'ABSPATH' ) || exit;
 
+use SFME\Debug\Debug_Logger;
+
 /**
  * Class User_Handler
  *
@@ -75,6 +77,9 @@ class User_Handler {
 				$user_id = $result;
 			} else {
 				// 4. Auto-create disabled — cannot log this user in.
+				$email = self::extract_email( $claims );
+				Debug_Logger::log( 'user_not_found', 'failure', $email, 'provisioning_disabled' );
+
 				return new \WP_Error(
 					'sfme_user_not_found',
 					esc_html__(
@@ -149,6 +154,8 @@ class User_Handler {
 		if ( ! empty( $claims['groups'] ) && is_array( $claims['groups'] ) ) {
 			User_Meta::update( $user_id, User_Meta::ENTRA_GROUPS, $claims['groups'] );
 		}
+
+		Debug_Logger::log( 'user_created', 'success', $email, '' );
 
 		return $user_id;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: sso, microsoft, entra, azure, single-sign-on
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 2.6.1
+Stable tag: 2.7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -90,6 +90,10 @@ Yes. Encrypted using libsodium (XSalsa20-Poly1305) or AES-256-GCM with a key der
 2. **Login page** — Microsoft sign-in button on the WordPress login form.
 
 == Changelog ==
+
+= 2.7.0 =
+* **Added:** Debug Log tab — enable debug logging in admin settings to capture the last 100 authentication sessions for troubleshooting.
+* **Added:** Delete Log button to clear all stored log entries.
 
 = 2.6.1 =
 * **Fixed:** WordPress.org plugin directory assets (icon, banner) served from the correct SVN path.

--- a/sso-for-microsoft-entra.php
+++ b/sso-for-microsoft-entra.php
@@ -3,7 +3,7 @@
  * Plugin Name:       SSO for Microsoft Entra
  * Plugin URI:        https://github.com/codetot-web/sso-for-microsoft-entra
  * Description:       Single Sign-On authentication for WordPress using Microsoft Entra ID (Azure AD) via OpenID Connect with PKCE.
- * Version:           2.6.1
+ * Version:           2.7.0
  * Requires at least: 6.0
  * Requires PHP:      8.0
  * Author:            Khoi Pro, CODE TOT
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @var string
  */
-define( 'SFME_VERSION', '2.6.1' );
+define( 'SFME_VERSION', '2.7.0' );
 
 /**
  * Database schema version.

--- a/sso-for-microsoft-entra.php
+++ b/sso-for-microsoft-entra.php
@@ -132,11 +132,18 @@ register_activation_hook(
 
 /**
  * Flush rewrite rules on deactivation to remove any custom endpoints the
- * plugin may have registered.
+ * plugin may have registered. Also clears stale auth log data so no
+ * sensitive session information (IP addresses, emails) remains in the DB
+ * after the plugin is deactivated.
  */
 register_deactivation_hook(
 	__FILE__,
 	function () {
 		flush_rewrite_rules();
+
+		// Clear auth log entries on deactivation.
+		if ( class_exists( '\\SFME\\Debug\\Debug_Logger' ) ) {
+			\SFME\Debug\Debug_Logger::clear_logs();
+		}
 	}
 );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -325,13 +325,39 @@ if ( ! function_exists( 'get_transient' ) ) {
 
 if ( ! function_exists( 'delete_transient' ) ) {
 	/**
-	 * Stub for delete_transient(). Removes key from in-memory store.
+	 * Stub for delete_transient().
 	 *
 	 * @param string $transient Transient name.
 	 * @return bool
 	 */
 	function delete_transient( string $transient ): bool {
 		unset( $GLOBALS['_sfme_transients'][ $transient ] );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	/**
+	 * Stub for wp_json_encode().
+	 *
+	 * @param mixed $data Data to encode.
+	 * @return string
+	 */
+	function wp_json_encode( $data ): string {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+		return json_encode( $data );
+	}
+}
+
+if ( ! function_exists( 'delete_option' ) ) {
+	/**
+	 * Stub for delete_option().
+	 *
+	 * @param string $option Option name.
+	 * @return bool
+	 */
+	function delete_option( string $option ): bool {
+		unset( $GLOBALS['_sfme_options'][ $option ] );
 		return true;
 	}
 }

--- a/tests/test-debug-logger.php
+++ b/tests/test-debug-logger.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests for the Debug_Logger class.
+ *
+ * @package SFME\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+use SFME\Debug\Debug_Logger;
+use SFME\Plugin;
+
+/**
+ * Class DebugLoggerTest
+ *
+ * @coversDefaultClass \SFME\Debug\Debug_Logger
+ */
+class DebugLoggerTest extends TestCase {
+
+	/**
+	 * Clean up after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		delete_option( Plugin::OPTION_AUTH_LOGS );
+		delete_option( Plugin::OPTION_DEBUG_LOG_ENABLED );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that log() does not write when debug logging is disabled.
+	 *
+	 * @covers ::log
+	 * @covers ::is_enabled
+	 * @covers ::get_logs
+	 * @return void
+	 */
+	public function test_log_does_not_write_when_disabled(): void {
+		// Ensure logging is OFF (default).
+		update_option( Plugin::OPTION_DEBUG_LOG_ENABLED, 0 );
+
+		Debug_Logger::log( 'login_success', 'success', 'test@example.com' );
+
+		$this->assertEmpty( Debug_Logger::get_logs(), 'Logs should be empty when debug is disabled.' );
+	}
+
+	/**
+	 * Test that log() writes entries when debugging is enabled.
+	 *
+	 * @covers ::log
+	 * @covers ::get_logs
+	 * @return void
+	 */
+	public function test_log_writes_entry_when_enabled(): void {
+		update_option( Plugin::OPTION_DEBUG_LOG_ENABLED, 1 );
+
+		Debug_Logger::log( 'login_success', 'success', 'test@example.com' );
+
+		$logs = Debug_Logger::get_logs();
+		$this->assertCount( 1, $logs );
+
+		$entry = $logs[0];
+		$this->assertSame( 'login_success', $entry['event'], 'Event type should match.' );
+		$this->assertSame( 'success', $entry['status'], 'Status should be success.' );
+		$this->assertSame( 'test@example.com', $entry['email'], 'Email should match.' );
+		$this->assertStringContainsString( 'error' === $entry['status'] ? '' : '', $entry['error'] ?? '' );
+		$this->assertArrayHasKey( 'timestamp', $entry, 'Entry should have a timestamp.' );
+		$this->assertArrayHasKey( 'ip', $entry, 'Entry should have an IP.' );
+	}
+
+	/**
+	 * Test that get_logs() returns newest entry first.
+	 *
+	 * @covers ::log
+	 * @covers ::get_logs
+	 * @return void
+	 */
+	public function test_logs_ordered_newest_first(): void {
+		update_option( Plugin::OPTION_DEBUG_LOG_ENABLED, 1 );
+
+		Debug_Logger::log( 'login_success', 'success', 'first@example.com' );
+		sleep( 1 );
+		Debug_Logger::log( 'login_success', 'success', 'second@example.com' );
+
+		$logs = Debug_Logger::get_logs();
+		$this->assertCount( 2, $logs );
+		$this->assertSame( 'second@example.com', $logs[0]['email'], 'Newest entry should be first.' );
+	}
+
+	/**
+	 * Test that logs are limited to MAX_ENTRIES (oldest evicted).
+	 *
+	 * @covers ::log
+	 * @covers ::get_logs
+	 * @return void
+	 */
+	public function test_logs_capped_at_max_entries(): void {
+		update_option( Plugin::OPTION_DEBUG_LOG_ENABLED, 1 );
+		$max = Debug_Logger::MAX_ENTRIES;
+
+		// Insert MAX_ENTRIES + 10 entries.
+		for ( $i = 0; $i < $max + 10; $i++ ) {
+			Debug_Logger::log( 'login_attempt', 'success', "user{$i}@example.com" );
+		}
+
+		$logs = Debug_Logger::get_logs();
+		$this->assertCount( $max, $logs, 'Logs should be capped at MAX_ENTRIES.' );
+
+		// The oldest 10 entries should be gone.
+		$emails = array_column( $logs, 'email' );
+		$this->assertContains( "user{$max}@example.com", $emails, 'Latest entries should be present.' );
+	}
+
+	/**
+	 * Test clear_logs() empties the log store.
+	 *
+	 * @covers ::clear_logs
+	 * @covers ::get_logs
+	 * @return void
+	 */
+	public function test_clear_logs_empties_store(): void {
+		update_option( Plugin::OPTION_DEBUG_LOG_ENABLED, 1 );
+
+		Debug_Logger::log( 'login_success', 'success', 'test@example.com' );
+		$this->assertNotEmpty( Debug_Logger::get_logs() );
+
+		Debug_Logger::clear_logs();
+		$this->assertEmpty( Debug_Logger::get_logs(), 'Logs should be empty after clear.' );
+	}
+
+	/**
+	 * Test is_enabled() reflects the option value.
+	 *
+	 * @covers ::is_enabled
+	 * @return void
+	 */
+	public function test_is_enabled_reflects_option(): void {
+		update_option( Plugin::OPTION_DEBUG_LOG_ENABLED, 0 );
+		$this->assertFalse( Debug_Logger::is_enabled(), 'is_enabled should be false when option is 0.' );
+
+		update_option( Plugin::OPTION_DEBUG_LOG_ENABLED, 1 );
+		$this->assertTrue( Debug_Logger::is_enabled(), 'is_enabled should be true when option is 1.' );
+
+		delete_option( Plugin::OPTION_DEBUG_LOG_ENABLED );
+		$this->assertFalse( Debug_Logger::is_enabled(), 'is_enabled should be false when option is not set.' );
+	}
+
+	/**
+	 * Test log() records failure status correctly.
+	 *
+	 * @covers ::log
+	 * @covers ::get_logs
+	 * @return void
+	 */
+	public function test_log_records_failure(): void {
+		update_option( Plugin::OPTION_DEBUG_LOG_ENABLED, 1 );
+
+		Debug_Logger::log( 'callback_error', 'failure', '', 'oidc_callback_failed' );
+
+		$logs = Debug_Logger::get_logs();
+		$this->assertCount( 1, $logs );
+		$this->assertSame( 'failure', $logs[0]['status'], 'Status should be failure.' );
+		$this->assertSame( 'oidc_callback_failed', $logs[0]['error'], 'Error code should match.' );
+	}
+}

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'codetot-web/sso-for-microsoft-entra',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'd40fa4ff7ef9296c57a935e320e744a5be1e7e63',
+        'reference' => '1d3483ccb5f5aee0efa295abde62cd706007e1ed',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'codetot-web/sso-for-microsoft-entra' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'd40fa4ff7ef9296c57a935e320e744a5be1e7e63',
+            'reference' => '1d3483ccb5f5aee0efa295abde62cd706007e1ed',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary

Adds a **Debug Log** tab to the plugin's admin settings page for troubleshooting SSO authentication issues.

## Changes

### New files
- `includes/debug/class-debug-logger.php` — `SFME\Debug\Debug_Logger` class that stores/retrieves/clears auth logs
- `tests/test-debug-logger.php` — 7 PHPUnit tests covering enabled/disabled, ordering, max entries, clear, and failure logging

### Modified files
- `includes/class-plugin.php` — Added `OPTION_DEBUG_LOG_ENABLED` and `OPTION_AUTH_LOGS` constants
- `includes/admin/class-settings-page.php` — Added Debug Log settings section with toggle + log table + Delete Log AJAX handler
- `includes/admin/class-settings-fields.php` — Added `debug_log_fields()` field definitions
- `includes/login/class-login-handler.php` — Logs callback errors, rate-limit triggers, and successful logins
- `includes/user/class-user-handler.php` — Logs user creation and provisioning failures
- `tests/bootstrap.php` — Added `wp_json_encode` and `delete_option` stubs
- Bumped to v2.7.0, updated changelog and readme

## How it works

1. Admin enables "Enable Debug Log" in Settings → Entra SSO → Debug Log
2. All subsequent auth events (success, failure, rate-limit, callback errors, provisioning) are logged
3. Max 100 entries — oldest evicted when full
4. "Delete Log" button clears all entries via AJAX
5. Default: off (no logs saved until enabled)

## Verification

- ✅ PHPUnit: 60 tests pass (7 new)
- ✅ PHP_CodeSniffer: No errors
- ✅ Handles disabled/empty/full states in the UI

Closes #26